### PR TITLE
Fix for Django 1.8 where private Template API has moved to django.template.base. Closes #2

### DIFF
--- a/macros/templatetags/macros.py
+++ b/macros/templatetags/macros.py
@@ -1,6 +1,10 @@
-from django import template
-from django.template import FilterExpression
+from django import template, VERSION
 from django.template.loader import get_template
+
+if VERSION[:3] >= (1, 8, 0):
+    from django.template.base import FilterExpression
+else:
+    from django.template import FilterExpression
 
 register = template.Library()
 


### PR DESCRIPTION
Copy from issue #2:

Private Template API has been moved to django.template.base as described in the [Release Notes](https://docs.djangoproject.com/en/1.8/releases/1.8/#cleanup-of-the-django-template-namespace)

Currently loading macros in a template raises Exception:

```
TemplateSyntaxError: 'macros' is not a valid tag library: ImportError raised loading macros.templatetags.macros: cannot import name FilterExpression
```
