### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,5 +77,5 @@ Bear in mind that defined and loaded macros are local to each template
 file and are not inherited through `{% extends ... %}` tags.
 
 
-.. |PyPI Version| image:: https://pypip.in/v/django-templates-macros/badge.png
+.. |PyPI Version| image:: https://img.shields.io/pypi/v/django-templates-macros.svg
    :target: https://pypi.python.org/pypi/django-templates-macros


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-templates-macros))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-templates-macros`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.